### PR TITLE
Add sleep to let the container get access to internet in ACI

### DIFF
--- a/src/docker/linux/Dockerfile
+++ b/src/docker/linux/Dockerfile
@@ -31,4 +31,5 @@ RUN  unzip terraform_${tfversion}_linux_amd64.zip \
 
 USER vsts
 
-ENTRYPOINT [ "/bin/bash", "-c", "./config.sh --unattended --replace && ./run.sh" ]
+# added 30 seconds sleep time to let the time to the ACI to get access to the Internet, otherwise, got some timeout on the agent registration...
+ENTRYPOINT [ "/bin/bash", "-c", "sleep 30 && ./config.sh --unattended --replace && ./run.sh" ]


### PR DESCRIPTION
I had some random timeout in the agent registration and I found this: https://docs.microsoft.com/en-us/azure/container-instances/container-instances-troubleshooting#windows-containers-slow-network-readiness

It suggests some network issue at the start of windows containers in ACI. I also observed this with Linux in that case. Adding a `sleep 30` before the agent registration in the entry point solved the issue.